### PR TITLE
Add initial Nuke plugin scaffolding

### DIFF
--- a/nuke_tool/README.md
+++ b/nuke_tool/README.md
@@ -1,0 +1,18 @@
+# Pixel3DMM Nuke Integration
+
+This directory contains a minimal wrapper for running the Pixel3DMM pipeline directly inside The Foundry Nuke.
+It exposes a small UI and helper functions to launch preprocessing, inference and tracking.
+
+## Installation
+1. Copy the `nuke_tool` directory into a location included in your Nuke plugin path or add its parent directory to `NUKE_PATH`.
+2. Ensure environment variables defined in `env_paths.py` are configured either via `~/.config/pixel3dmm/.env` or by editing the file directly.
+
+## Usage
+In Nuke's Python console run:
+```python
+import nuke_tool.menu as pm
+pm.add_menu()
+```
+This adds a **Pixel3DMM** entry to the main menu which opens a simple panel for selecting a video or image sequence.
+
+Running the pipeline will create the preprocessing and tracking results in the locations specified by the environment variables.

--- a/nuke_tool/__init__.py
+++ b/nuke_tool/__init__.py
@@ -1,0 +1,5 @@
+"""Nuke wrapper for the Pixel3DMM pipeline."""
+
+from .run_pipeline import run_full_pipeline
+
+__all__ = ["run_full_pipeline"]

--- a/nuke_tool/interface.py
+++ b/nuke_tool/interface.py
@@ -1,0 +1,37 @@
+"""Simple PySide2 interface for running the pipeline."""
+
+try:
+    from PySide2 import QtWidgets
+except ImportError:  # Nuke 15 may expose PySide6
+    from PySide6 import QtWidgets
+
+from .run_pipeline import run_full_pipeline
+
+
+class Pixel3DMMPanel(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Pixel3DMM Pipeline")
+        self.setLayout(QtWidgets.QVBoxLayout())
+
+        self.path_edit = QtWidgets.QLineEdit(self)
+        browse_btn = QtWidgets.QPushButton("Browse", self)
+        run_btn = QtWidgets.QPushButton("Run", self)
+
+        self.layout().addWidget(QtWidgets.QLabel("Video or Image Folder:"))
+        self.layout().addWidget(self.path_edit)
+        self.layout().addWidget(browse_btn)
+        self.layout().addWidget(run_btn)
+
+        browse_btn.clicked.connect(self._browse)
+        run_btn.clicked.connect(self._run)
+
+    def _browse(self) -> None:
+        path = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Directory")
+        if path:
+            self.path_edit.setText(path)
+
+    def _run(self) -> None:
+        path = self.path_edit.text().strip()
+        if path:
+            run_full_pipeline(path)

--- a/nuke_tool/menu.py
+++ b/nuke_tool/menu.py
@@ -1,0 +1,25 @@
+"""Menu integration for Nuke."""
+
+try:
+    import nuke
+except Exception:  # Running outside Nuke
+    nuke = None
+
+from .interface import Pixel3DMMPanel
+
+
+_panel = None
+
+
+def launch_panel():
+    global _panel
+    if _panel is None:
+        _panel = Pixel3DMMPanel()
+    _panel.show()
+
+
+def add_menu():
+    """Add menu entry in Nuke to launch the panel."""
+    if nuke is None:
+        return
+    nuke.menu('Nuke').addCommand('Pixel3DMM/Run Pipeline', launch_panel)

--- a/nuke_tool/run_pipeline.py
+++ b/nuke_tool/run_pipeline.py
@@ -1,0 +1,34 @@
+"""Functions to execute the Pixel3DMM pipeline from Nuke."""
+from pathlib import Path
+from omegaconf import OmegaConf
+
+from pixel3dmm import env_paths
+from scripts.run_preprocessing import main as run_preprocessing
+from scripts.network_inference import main as run_inference
+from scripts.track import main as run_tracking
+
+from .utils import video_to_name
+
+
+def _run_inference(video_name: str, prediction_type: str) -> None:
+    cfg = OmegaConf.load(f"{env_paths.CODE_BASE}/configs/base.yaml")
+    cfg.model.prediction_type = prediction_type
+    cfg.video_name = video_name
+    run_inference(cfg)
+
+
+def _run_tracking(video_name: str) -> None:
+    cfg = OmegaConf.load(f"{env_paths.CODE_BASE}/configs/tracking.yaml")
+    cfg.video_name = video_name
+    run_tracking(cfg)
+
+
+def run_full_pipeline(video_or_images_path: str) -> None:
+    """Run preprocessing, inference and tracking."""
+    run_preprocessing(video_or_images_path)
+    name = video_to_name(video_or_images_path)
+
+    for pred in ("normals", "uv_map"):
+        _run_inference(name, pred)
+
+    _run_tracking(name)

--- a/nuke_tool/utils.py
+++ b/nuke_tool/utils.py
@@ -1,0 +1,11 @@
+"""Utility helpers for the Nuke integration."""
+
+from pathlib import Path
+
+
+def video_to_name(path: str) -> str:
+    """Return a name for the given video or image folder."""
+    p = Path(path)
+    if p.is_dir():
+        return p.name
+    return p.stem


### PR DESCRIPTION
## Summary
- add `nuke_tool` directory for The Foundry Nuke integration
- implement basic menu, UI panel and pipeline wrapper
- document usage and installation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef6548674832cb091fab9788af9a7